### PR TITLE
fix: exit code - 1 when engines don't satisfy

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,5 +26,5 @@ for (let [eng, version] of Object.entries(engines)) {
 if (isntOk) {
   console.log(chalk.yellow('---------------------------------------------------------------------'))
   console.log(chalk.white(`Please update the above ☝ ${chalk.red('errored')} engines to the required ones in package.json`))
-  process.exit(0)
+  process.exit(1)
 }


### PR DESCRIPTION
The process doesn't exit with failure on dis-satisfying versions of the engines.
Changes exitCode from :zero: to :one: 