### PR TITLE
suggestion: prefer global / one-off execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Checks the engines in *package.json* - **node/npm**
 
 ## Install
 
-`npm i engines-ok -D`
-
-or globally as
-
 `npm i engines-ok -g`
+
+or, if you'd prefer installing it locally within your project, as
+
+`npm i engines-ok -D`
 
 ## Usage
 
@@ -28,7 +28,7 @@ package.json
 
 ```js
 "scripts": {
-  "preinstall": "npm i engines-ok@latest -D && engines-ok"
+  "preinstall": "npx engines-ok"
 }
 ```
 


### PR DESCRIPTION
Hey 👋  This PR is more of a _suggestion_  than a _fix_.

### What's changed?

- Updates README to prefer one-off executions / global installation over adding `engines-ok` as a dev dependency

### Motivation

Dependency installation usually happens once during project setup, and just a handful of times post setup when packages are added or updated. The current flow of the README, and the code snippets, seems to highlight that users should install this cli as a dev dependency of their project. Given how infrequently `npm install` is done, I'd suggest that the README be updated to:

1. use `npx` over `npm install -D`
2. highlight globally installing the cli, and to suggest installing it as a dev dependency only if absolutely required.

Thoughts?



